### PR TITLE
質問選択機能: 質問一覧・絞り込み・登録処理を実装

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -69,7 +69,7 @@
   }
   
 .back-button {
-  margin-top: 80px;
+  margin-top: 50px;
 
   @media (max-width: 768px) {
     margin-top: 72px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @use "flash";
 @use "calendar_styles";
 @use "sidebar";
+@use "questions";
 
 
 .text-pink {

--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -1,0 +1,89 @@
+
+.filter-container {
+  background-color: #fff3f7;
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin: 1rem 0;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+
+  .filter-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    
+    .filter-title {
+      font-weight: bold;
+      font-size: 1.2rem;
+      color: #444;
+    }
+
+    i {
+        font-size: 1.3rem;
+        color: #888;
+    }
+  }
+
+  .filter-row {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    @media (min-width: 600px) {
+      flex-direction: row;
+      justify-content: space-between;
+      }
+    }
+
+    .filter-group {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+
+      label {
+        font-size: 0.9rem;
+        color: #666;
+        margin-bottom: 0.25rem;
+    }
+
+    select.filter-input {
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      background: white;
+      font-size: 1rem;
+      margin-bottom: 1rem;
+    }
+  }
+
+  .keyword-input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background: white;
+    font-size: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .search-btn {
+    width: 100%;
+    background-color: #fff3cd;
+    border: 1px solid #ffe08a;
+    color: #333;
+    font-weight: bold;
+    border-radius: 9999px;
+    padding: 0.75rem;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.3s ease;
+
+    &.hover {
+      background-color: #ffeaa7;
+    }
+  }
+
+  .overlay {
+    display: none;
+  }
+}

--- a/app/controllers/question_selections_controller.rb
+++ b/app/controllers/question_selections_controller.rb
@@ -1,0 +1,4 @@
+class QuestionSelectionsController < ApplicationController
+  def create
+  end
+end

--- a/app/controllers/question_selections_controller.rb
+++ b/app/controllers/question_selections_controller.rb
@@ -1,7 +1,57 @@
 class QuestionSelectionsController < ApplicationController
-  def create
-    head :found
+  before_action :set_visit, only: [ :index, :create ] # index、createアクションの前に対象のVisitを取得
+
+  def index
+    @visit = Visit.find(params[:visit_id]) #  Visitに紐づく質問を取得
+    @question_selections = @visit.question_selections.includes(:question) # Visitに登録されている質問選択リストを効率よく取得するために、登録済みの質問(QuestionSelection)一覧を取得 includes(:question)により、各QuestionSelectionが持つquestionを事前にまとめて取得（N+1 問題防止）
+  end
+
+  def select # 質問を絞り込み表示する画面の処理
+    @date = @visit.visit_date # ビューで表示するために@visitに設定された日付を取得
+    @departments = Department.all # 全診療科、全カテゴリを取得して、フィルター表示用に渡す
+    @question_categories = QuestionCategory.all
+
+    # 全質問を取得し、ここからさらに絞り込む
+    @questions = Question.all
+
+    # パラメータにdepartment_idがあれば診療科ごとに絞り込む
+    if params[:department_id].present?
+      @questions = @questions.where(department_id: params[:department_id]) # present?を使い、パラメータが空やnilの場合はフィルターしないことで意図しない絞り込みを防ぐ
+    end
+
+    if params[:question_category_id].present? # 質問の内容で部分一致検索するため。
+      @questions = @questions.where(question_category_id: params[:question_category_id])
+    end
+
+    if params[:keyword].present? # 質問の内容で部分一致検索するため
+      @questions = @questions.where("questions.content ILIKE ?", "%#{params[:keyword]}%") # ILIKEを使うことでPostgreSQL環境での 大文字小文字を無視した検索 に対応。SQLインジェクション防止のため、パラメータ埋め込みはプレースホルダ (?) を使用。
+    end
+
+    # 既に選択済みの質問IDを取得（重複選択防止のため）
+    @selected_question_ids = @visit.question_selections.pluck(:question_id)
+  end
+
+
+  def create # 質問選択画面から選ばれた質問を保存
+    question_ids = selection_params[:question_ids] || [] # フォームから渡されたパラメータquestion_idsを取得。パラメータがない場合も考慮して空配列にfallbackすることでエラー防止。
+    question_ids = question_ids.reject(&:blank?) # 空白を除外する
+    existing_question_ids = @visit.question_selections.pluck(:question_id)
+    new_question_ids = question_ids.map(&:to_i) - existing_question_ids
+
+    new_question_ids.each do |question_id|
+      @visit.question_selections.create(question_id: question_id, selected_at: Time.current)
+    end
+
+    redirect_to visit_question_selections_path(@visit), notice: "質問が追加されました"
+  end
+
+    private
+
+  def set_visit
+    @visit = Visit.find(params[:visit_id])
+  end
+
+  def selection_params
+    params.permit(question_ids: [])
   end
 end
-
-# ここは後から修正

--- a/app/controllers/question_selections_controller.rb
+++ b/app/controllers/question_selections_controller.rb
@@ -1,4 +1,7 @@
 class QuestionSelectionsController < ApplicationController
   def create
+    head :found
   end
 end
+
+# ここは後から修正

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -3,7 +3,7 @@ class QuestionsController < ApplicationController # #質問テンプレートを
     @departments = Department.all # #質問を絞るための全ての診療科を取得してビューに出す
     @question_categories = QuestionCategory.all # #質問カテゴリーも取得
     @questions = Question.all # #全ての質問テンプレートを取得
-    @visit = Visit.new
+    @visit = Visit.find(params[:visit_id])
   end
 
   def search

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,11 @@
+class QuestionsController < ApplicationController # #質問テンプレートを扱うコントローラ
+  def select # #「質問を選ぶ」画面を表示する
+    @departments = Department.all # #質問を絞るための全ての診療科を取得してビューに出す
+    @question_categories = QuestionCategory.all # #質問カテゴリーも取得
+    @questions = Question.all # #全ての質問テンプレートを取得
+    @visit = Visit.new
+  end
+
+  def search
+  end
+end

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -6,7 +6,7 @@ class VisitsController < ApplicationController
     selected_date = params[:date].presence || Date.today # #URLにdate=2025-06-07みたいなパラメータがついていたらその日付、なければ今日の日付を使う 「選択された日付、または今日」をselected_dateに入れる
     @visit = Visit.new(visit_date: selected_date) # #フォーム用visitインスタンス 、日付フィールドが空じゃなく選択された日（または今日）になってる。
     @departments = Department.all # #プルダウンに診療科一覧を取得 フォームの「診療科」セレクトボックスに使われる
-    @visits = current_user.visits.where("visit_date >= ?", Date.today).order(visit_date: :asc) # #昇順に（今日）以上の日付のレコードを取得
+    @visits = current_user.visits.includes(question_selections: :question).where("visit_date >= ?", Date.today).order(visit_date: :asc) # #昇順に（今日）以上の日付のレコードを取得
   end
 
   def new

--- a/app/helpers/question_selections_helper.rb
+++ b/app/helpers/question_selections_helper.rb
@@ -1,0 +1,2 @@
+module QuestionSelectionsHelper
+end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -1,0 +1,2 @@
+module QuestionsHelper
+end

--- a/app/javascript/questions/select.js
+++ b/app/javascript/questions/select.js
@@ -1,0 +1,10 @@
+$(function () {
+  const $filterToggle = $('#filterToggle');
+  const $filterCollapse = $('#filterCollapse');
+
+  if ($filterToggle.length && $filterCollapse.length) {
+    $filterToggle.on('click', function () {
+      $filterCollapse.stop(true, true).slideToggle(200);
+    });
+  }
+});

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,9 +3,11 @@ class Question < ApplicationRecord # #Questionモデルを定義
   belongs_to :question_category, optional: true # この質問は1つのカテゴリ(question_category)に属する
   has_many :question_selections, dependent: :destroy # ユーザーの選択履歴と関連、質問削除時に選択も削除
 
-  validates :content, presence: true # #質問内容（content）は必須。空の場合は保存できない
-  validates :content, uniqueness: { message: "は、同じ診療科、カテゴリにすでにあります" }
+  validates :content, presence: true # 　質問内容（content）は必須。空の場合は保存できない
+  validates :content, uniqueness: { scope: [ :department_id, :question_category_id ], message: "は、同じ診療科、カテゴリにすでにあります" }
   validate :department_or_category_must_be_present # #独自のバリデーション 診療科（department）もカテゴリ（question_category）も両方が空だと保存できない アプリケーションレベルのチェック
+
+  # 検索フィルターは、また後で
 
   private
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -4,6 +4,10 @@ class Visit < ApplicationRecord
   has_many :documents, dependent: :destroy
   has_many :recordings, dependent: :destroy
 
+  #  Visitモデルが複数のquestion_selectionsを持つ
+  has_many :question_selections, dependent: :destroy
+  has_many :questions, through: :question_selections
+
   # 必須項目のバリデーション
   validates :visit_date, :hospital_name, :purpose, :appointed_at, presence: true
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,11 +28,13 @@
     <%= javascript_include_tag "application", type: "module", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "/js/calendar.js" %>
     <%= javascript_include_tag "/js/locales-all.global.js" %>
+    <%= javascript_include_tag "questions/select.js" %>
 
   </head>
 
   <body>
-  <% if user_signed_in? %>
+    <%# 「ログインしている場合」かつ「questions#selectまたはquestions#searchアクションではない場合」だけ処理を実行したい %>
+  <% if user_signed_in? && !(controller_name == 'questions' && action_name.in?(%w[select search])) %>
     <%# トグルボタン %>
     <div class="login-user-banner d-flex justify-content-between align-items-center">
       <div class="d-flex align-items-center">
@@ -51,7 +53,7 @@
       <div class="inner">
         <ul class="sidebar-nav">
           <li><%= link_to "スケジュール", visits_path %></li>
-          <li><%= link_to "質問リスト", "#" %></li>
+          <li><%= link_to "質問を選ぶ", questions_select_path %></li>
           <li><%= link_to "プロフィール", "#" %></li>
           <li><%= link_to "設定（未実装）", "#" %></li>
         </ul>

--- a/app/views/questions/_filter_form.html.erb
+++ b/app/views/questions/_filter_form.html.erb
@@ -1,0 +1,44 @@
+<div class="filter-container px-3" id="filterContainer">
+    <!-- 絞り込みヘッダー -->
+    <div class="filter-header" id="filterToggle" style="cursor: pointer;">
+      <span class="filter-title text-center">絞り込み機能はこちら</span>
+      <i class="bi bi-patch-question"></i>
+    </div>
+
+    <!-- 開閉されるフォーム本体 -->
+    <div class="filter-body" id="filterCollapse" style="display: none;">
+      <div class="mb-3">
+        <%= form_with url: search_questions_path, method: :get, local: true, data: { turbo: false } do %>
+          <div class="filter-row">
+            <div class="filter-group">
+              <label class="filter-label">診療科</label>
+              <%= select_tag :department_id,
+                options_for_select([['全て', '']] + @departments.map { |dept| [dept.name, dept.id] }, params[:department_id]),
+                class: 'filter-input', id: 'departmentFilter' %>
+            </div>
+
+            <div class="filter-group">
+              <label class="filter-label">カテゴリ</label>
+              <%= select_tag :question_category_id,
+                options_for_select([['全て', '']] + @question_categories.map { |cat| [cat.category_name, cat.id] }, params[:question_category_id]),
+                class: 'filter-input', id: 'categoryFilter' %>
+            </div>
+          </div>
+
+          <div>
+            <%= text_field_tag :keyword, params[:keyword], {
+              class: 'keyword-input',
+              placeholder: 'キーワード',
+              id: 'keywordInput',
+              autocomplete: 'off'
+            } %>
+          </div>
+
+          <div class="mt-3">
+            <button type="submit" class="search-btn">検索</button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/questions/search.html.erb
+++ b/app/views/questions/search.html.erb
@@ -1,0 +1,2 @@
+<h1>Questions#search</h1>
+<p>Find me in app/views/questions/search.html.erb</p>

--- a/app/views/questions/select.html.erb
+++ b/app/views/questions/select.html.erb
@@ -1,2 +1,32 @@
-<h1>Questions#select</h1>
-<p>Find me in app/views/questions/select.html.erb</p>
+<%# 戻るボタン %>
+<div class="d-flex justify-content-start">
+  <%= link_to visits_path(date: @visit.visit_date), class: "btn btn-outline-secondary d-flex align-items-center back-button" do %>
+    <i class="bi bi-arrow-left-circle-fill me-2"></i>
+    戻る
+  <% end %>
+</div>
+
+<h1 class="page-title text-center">質問を選ぶ</h1>
+
+<%= render 'filter_form' %>
+
+<%# メインコンテンツ %>
+<div class="main-content">
+  <%= form_with model: @visit, method: :post, local: true do |f| %>
+    <div class="question-card">
+      <div class="question-header">
+        <i class="bi bi-chat-text"></i>
+        <span>該当する質問</span>
+      </div>
+      <ul class="question-list" id="questionList">
+        <%= f.collection_checkboxes(:question_ids, Question.all, :id, :content) do |b| %>
+          <li class="question-list">
+            <%= b.label { b.check_box + b.text } %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <%= f.submit "次へ", class: "btn-pink" %>
+  <% end %>
+</div>

--- a/app/views/questions/select.html.erb
+++ b/app/views/questions/select.html.erb
@@ -1,0 +1,2 @@
+<h1>Questions#select</h1>
+<p>Find me in app/views/questions/select.html.erb</p>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "bootstrap.bundle.min.js"
+pin "questions/select", preload: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,26 @@
 Rails.application.routes.draw do
+  devise_for :users # #ユーザーのログイン・登録などに必要なルート
   get "question_selections/create"
   get "questions/select"
   get "questions/search"
-  devise_for :users # #ユーザーのログイン・登録などに必要なルート
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "home#index" # #トップページ（/）にアクセス
+
+  ## 質問テンプレを選択、検索
+  resources :questions, only: [] do
+    collection do
+      get :select ## 質問を選ぶ
+      get :search # #検索(turboを使用したい)
+    end
+  end
+
+  ## 質問選択ほ保存確認記録をする
+  resources :question_selections, only: [ :create ] do
+    collection do
+      get :summary # #選んだ質問リスト画面
+      post :finalize # #質問を聞けたかどうかの最終確認
+    end
+  end
 
 
   resources :visits, only: [ :index, :new, :create, :edit, :update, :destroy ] do # #visitsリソースに関するルート
@@ -12,13 +28,4 @@ Rails.application.routes.draw do
       get "by_date"
     end
   end
-
-  resources :questions, only: [] do
-    collection do
-      get :select
-      get :search
-    end
-  end
-
-  resources :question_selections, only: [:create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get "question_selections/create"
+  get "questions/select"
+  get "questions/search"
   devise_for :users # #ユーザーのログイン・登録などに必要なルート
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "home#index" # #トップページ（/）にアクセス
@@ -9,4 +12,13 @@ Rails.application.routes.draw do
       get "by_date"
     end
   end
+
+  resources :questions, only: [] do
+    collection do
+      get :select
+      get :search
+    end
+  end
+
+  resources :question_selections, only: [:create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,31 +1,29 @@
 Rails.application.routes.draw do
-  devise_for :users # #ユーザーのログイン・登録などに必要なルート
-  get "question_selections/create"
-  get "questions/select"
-  get "questions/search"
+  devise_for :users # ユーザー認証機能
   get "up" => "rails/health#show", as: :rails_health_check
-  root to: "home#index" # #トップページ（/）にアクセス
 
-  ## 質問テンプレを選択、検索
-  resources :questions, only: [] do
+  root to: "home#index"
+
+  # 診察記録(visits)と紐づく予定
+  resources :visits, only: [ :index, :new, :create, :edit, :update, :destroy ] do
     collection do
-      get :select ## 質問を選ぶ
-      get :search # #検索(turboを使用したい)
+      get :by_date # 日付で絞り込む一覧取得
     end
-  end
 
-  ## 質問選択ほ保存確認記録をする
-  resources :question_selections, only: [ :create ] do
-    collection do
-      get :summary # #選んだ質問リスト画面
-      post :finalize # #質問を聞けたかどうかの最終確認
+    # 診察記録に紐づく質問選択・編集　visitにネストする
+    resources :question_selections, only: [ :index, :create, :edit, :update ] do
+      collection do
+        get :select # 質問選択画面
+        post :confirm # 確認画面へPOST送信する
+        post :finalize   # 最終登録処理として
+      end
+
+      member do
+        patch :toggle_answered # 質問個別に回答済み/未回答をトグルするため
+      end
     end
-  end
 
-
-  resources :visits, only: [ :index, :new, :create, :edit, :update, :destroy ] do # #visitsリソースに関するルート
-    collection do
-      get "by_date"
-    end
+    # 質問選択【とりあえずajax】
+    get :search_questions, on: :collection
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,11 +52,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_26_080013) do
   create_table "question_selections", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "question_id", null: false
-    t.datetime "selected_at", null: false
+    t.datetime "selected_at", null: false ##どの質問を聞くか
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "visit_id", null: false
-    t.boolean "asked", default: false, null: false
+    t.bigint "visit_id", null: false ##どの診察で聞くか
+    t.boolean "asked", default: false, null: false ##実際に「聞けたかどうか」
     t.index ["question_id"], name: "index_question_selections_on_question_id"
     t.index ["user_id"], name: "index_question_selections_on_user_id"
     t.index ["visit_id", "question_id"], name: "index_question_selections_on_visit_id_and_question_id", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,6 +38,8 @@ def create_question(department_name, category_name, content) # #3つのパラメ
   )
 end
 
+# #「診療科の名前（例：内科）」「カテゴリ名（例：薬）」「質問本文」となっている
+
 # --- 診療科別質問データ ---
 department_question_data = [
   [ "内科", nil, "この症状はどのような病気の可能性がありますか？" ],

--- a/test/controllers/question_selections_controller_test.rb
+++ b/test/controllers/question_selections_controller_test.rb
@@ -1,8 +1,44 @@
 require "test_helper"
 
 class QuestionSelectionsControllerTest < ActionDispatch::IntegrationTest
-  test "should get create" do
-    get question_selections_create_url
-    assert_response :success
+  test "should create question_selection" do
+    # ユーザー作成（name が必要な場合を想定）
+    user = User.create!(
+      email: "test@example.com",
+      password: "password",
+      name: "テストユーザー"
+    )
+
+    # 診療科・カテゴリ作成
+    department = Department.create!(name: "内科")
+    question_category = QuestionCategory.create!(category_name: "薬")
+
+    # 質問テンプレート作成
+    question = Question.create!(
+      content: "テスト質問",
+      department: department,
+      question_category: question_category
+    )
+
+    # 診察記録作成（Visit）
+    visit = Visit.create!(
+      user: user,
+      department: department,
+      hospital_name: "テスト病院",
+      purpose: "検査",
+      appointed_at: Time.current,
+      visit_date: Date.today
+    )
+
+    # POST リクエストで question_selection を作成
+    post question_selections_path,
+         params: {
+           question_selection: {
+             question_id: question.id,
+             visit_id: visit.id
+           }
+         }
+    # レスポンスがリダイレクトであることを確認
+    assert_response :redirect
   end
 end

--- a/test/controllers/question_selections_controller_test.rb
+++ b/test/controllers/question_selections_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class QuestionSelectionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get question_selections_create_url
+    assert_response :success
+  end
+end

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class QuestionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get select" do
+    get questions_select_url
+    assert_response :success
+  end
+
+  test "should get search" do
+    get questions_search_url
+    assert_response :success
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,10 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
## 概要
- 質問テンプレートから質問を選択できる機能を追加しました
- 診療科・カテゴリ・キーワードによる質問フィルター機能を実装
- 質問選択・登録機能を QuestionSelectionsController に追加

## 変更内容
- QuestionSelectionsController: index / select / create アクション追加
- 質問モデルの重複登録バリデーション追加
- 質問選択画面の view, scss, JavaScript を作成
- ルーティングを visits にネストする形で整理