### PR TITLE
テーブルの不要カラム削除など

### DIFF
--- a/app/controllers/question_selections_controller.rb
+++ b/app/controllers/question_selections_controller.rb
@@ -117,9 +117,9 @@ class QuestionSelectionsController < ApplicationController
     params.require(:visit).permit(question_ids: [])
   end
 
-  def update_params
-    params.require(:question_selection).permit(:asked, :memo)
-  end
+  # def update_params
+  #   params.require(:question_selection).permit(:asked, :memo)
+  # end
 
   # 質問絞り込み（診療科・カテゴリ・キーワード対応）
   def build_questions_query

--- a/app/controllers/question_selections_controller.rb
+++ b/app/controllers/question_selections_controller.rb
@@ -117,10 +117,6 @@ class QuestionSelectionsController < ApplicationController
     params.require(:visit).permit(question_ids: [])
   end
 
-  # def update_params
-  #   params.require(:question_selection).permit(:asked, :memo)
-  # end
-
   # 質問絞り込み（診療科・カテゴリ・キーワード対応）
   def build_questions_query
     questions = Question.all

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module YorisoiNote2
     config.autoload_lib(ignore: %w[assets tasks])
     config.i18n.default_locale = :ja # #日本語にする
     config.action_dispatch.allow_browser = true
+    config.active_record.schema_format = :ruby
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,6 @@ module YorisoiNote2
     config.autoload_lib(ignore: %w[assets tasks])
     config.i18n.default_locale = :ja # #日本語にする
     config.action_dispatch.allow_browser = true
-    config.active_record.schema_format = :ruby
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
         end
 
         # 診察記録に紐づく質問選択・編集
-        resources :question_selections, only: [ :index, :create, :update ]
+        resources :question_selections, only: [ :index, :create, :update, :destroy ]
 
         # 診療記録に紐ついている録音
         resources :recordings, only: [ :new, :create, :show, :destroy ]

--- a/db/migrate/20250611043657_update_visits_table.rb
+++ b/db/migrate/20250611043657_update_visits_table.rb
@@ -1,6 +1,0 @@
-class UpdateVisitsTable < ActiveRecord::Migration[8.0]
-  def change
-    remove_column :visits, :doctor_name, :string
-    add_column :visits, :appointed_at, :datetime, null: false
-  end
-end

--- a/db/migrate/20250617050330_add_appointed_at_to_visits.rb
+++ b/db/migrate/20250617050330_add_appointed_at_to_visits.rb
@@ -1,0 +1,5 @@
+class AddAppointedAtToVisits < ActiveRecord::Migration[8.0]
+  def change
+    add_column :visits, :appointed_at, :datetime, null: false
+  end
+end

--- a/db/migrate/20250618180651_remove_doctor_name_from_visits.rb
+++ b/db/migrate/20250618180651_remove_doctor_name_from_visits.rb
@@ -1,5 +1,0 @@
-class RemoveDoctorNameFromVisits < ActiveRecord::Migration[8.0]
-  def change
-    remove_column :visits, :doctor_name, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_02_202256) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_04_200939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_02_202256) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_04_200939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -105,8 +105,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_02_202256) do
   create_table "recordings", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "visit_id", null: false
-    t.string "file_path", null: false # 削除したい
-    t.text "memo" # 削除したい
     t.datetime "recorded_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_04_200939) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_02_202256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/fixtures/recordings.yml
+++ b/test/fixtures/recordings.yml
@@ -3,13 +3,9 @@
 one:
   user: one
   visit: one
-  file_path: MyString
-  memo: MyText
   recorded_at: 2025-05-22 10:47:29
 
 two:
   user: two
   visit: two
-  file_path: MyString
-  memo: MyText
   recorded_at: 2025-05-22 10:47:29


### PR DESCRIPTION
- recordingsテーブルから不要なmemo / file_pathカラムを削除
- visitsテーブルのマイグレーション整理
- schema.rb の整合性調整（migrate:reset 済み）
- 不要なマイグレーション削除
- fixture修正
