### PR TITLE
当日受診の予定も登録できるようにバリデーションを修正

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -5,7 +5,9 @@ class VisitsController < ApplicationController
     selected_date = params[:date].presence || Date.today # #URLにdate=2025-06-07みたいなパラメータがついていたらその日付、なければ今日の日付を使う 「選択された日付、または今日」をselected_dateに入れる
     @visit = Visit.new(visit_date: selected_date) # #フォーム用visitインスタンス 、日付フィールドが空じゃなく選択された日（または今日）になってる。
     @departments = Department.all # #プルダウンに診療科一覧を取得 フォームの「診療科」セレクトボックスに使われる
-    @visits = current_user.visits.where("visit_date >= ?", Date.today).order(visit_date: :asc) # #昇順に（今日）以上の日付のレコードを取得
+    @visits = current_user.visits
+              .where("appointed_at >= ?", Time.current)
+              .order(:appointed_at)
   end
 
   def new

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -58,8 +58,8 @@ class Visit < ApplicationRecord
   def visit_date_cannot_be_in_the_past
     return if visit_date.blank?
 
-    if visit_date <= Time.zone.today
-      errors.add(:visit_date, "は、今日より後の日付を指定してください。")
+    if visit_date < Time.zone.today
+      errors.add(:visit_date, "は、今日以降の日付を指定してください。")
     end
   end
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -23,6 +23,7 @@
 #
 
 class Visit < ApplicationRecord
+  before_validation :combine_date_and_time
   belongs_to :user
   belongs_to :department
   has_many :documents, dependent: :destroy

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -48,6 +48,12 @@ class Visit < ApplicationRecord
 
   private
 
+  def combine_date_and_time
+    return if visit_date.blank? || appointed_at.blank?
+
+    time_str = appointed_at.is_a?(String) ? appointed_at : appointed_at.strftime("%H:%M")
+    self.appointed_at = Time.zone.parse("#{visit_date} #{time_str}")
+  end
   # visit_date が「今日より後」かどうか
   def visit_date_cannot_be_in_the_past
     return if visit_date.blank?


### PR DESCRIPTION
### バリデーション等修正しました。
設計に問題がないか、ご確認をお願いいたします。

## 背景
### 元のバリデーション
```ruby
if visit_date <= Time.zone.today
  errors.add(:visit_date, "は、今日より後の日付を指定してください。")
end
```

この書き方だと「今日もNG」になってしまう。
- **当日受診の予定**（例: 今日の午後に急遽病院に行く）を登録できなかった。

## 実際の医療現場で起こること
- 医療現場では「今すぐに大きな病院へ受診しなければならない」というケースがよくあるため、「日付は今日でもOK」にしたい。
- ただし、**時間だけは現在時刻以降じゃないとダメ**にしたい

## 修正の目的
### 1. **visit_date のバリデーション**
- 「今日」も許可する（なので `<` に修正）
- 「今日以降」であれば通るよう修正

### 2. **appointed_at のバリデーション**
- 「今より後の時刻」でなければエラー
- 「当日・未来の時刻」だけ登録可能にしました