### PR TITLE
メール送付初期設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ group :development do
   gem "pry"
   gem "pry-byebug"
   gem "pry-rails"
+  gem "letter_opener"
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -218,6 +220,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -499,6 +512,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  letter_opener
+  letter_opener_web
   pg (~> 1.1)
   propshaft
   pry

--- a/app/mailers/visit_mailer.rb
+++ b/app/mailers/visit_mailer.rb
@@ -1,2 +1,10 @@
 class VisitMailer < ApplicationMailer
+  def reminder
+    @visit = params[:visit]
+    @user = @visit.user
+    mail(
+      to:
+      @user.email,
+      subject: "【リマインダー】#{@visit.hospital_name}の受診予定")
+  end
 end

--- a/app/mailers/visit_mailer.rb
+++ b/app/mailers/visit_mailer.rb
@@ -1,0 +1,2 @@
+class VisitMailer < ApplicationMailer
+end

--- a/app/views/visit_mailer/reminder.html.erb
+++ b/app/views/visit_mailer/reminder.html.erb
@@ -1,0 +1,10 @@
+<h1><%= @user.name %> さん</h1>
+<p>次回の受診予定についてご案内いたします。</p>
+
+<ul>
+  <li>病院名： <%= @visit.hospital_name %></li>
+  <li>受診日： <%= @visit.visit_date %></li>
+  <li>目的： <%= @visit.purpose %></li>
+</ul>
+
+<p>ログインをして詳細を確認してください： <%= link_to "こちらから確認できます。", root_url %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,8 +17,8 @@ module YorisoiNote2
     config.autoload_lib(ignore: %w[assets tasks])
     config.i18n.default_locale = :ja # #日本語にする
     config.action_dispatch.allow_browser = true
+    config.action_mailer.default_url_options = { host: "localhost", port: 5000 }
     # Configuration for the application, engines, and railties goes here.
-    #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     config.time_zone = "Tokyo" # タイムゾーンを東京に設定 録音機能で使用

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,8 +38,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { host: "localhost", port: 5000 }
+  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.smtp_settings = {
     address: "smtp.gmail.com",
     domain: "gmail.com",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users # ユーザーのログイン・登録などに必要なルート
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "home#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   devise_for :users # ユーザーのログイン・登録などに必要なルート
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "home#index"


### PR DESCRIPTION
受診予定作成時の通知メール、リマインダー送信を実装しています。
- letter_opener / letter_opener_web を導入し、開発環境でブラウザからメール確認できるように設定
- VisitMailer を作成し、受診予定のリマインダーメールを送信できるようにした
- reminder.html.erb を作成し、受診情報（病院名・受診日・目的）を本文に表示
- メール本文にアプリへのリンクを追加（root_url 使用）
- config/environments/development.rbのdefault_url_optionsをlocalhost:5000 に修正（bin/dev に対応）
- routes.rbに/letter_opener を追加してブラウザからメールを確認できるようにした

### 動作確認
- VisitMailerをコンソールから呼び出し、メールがtmp/letter_openerに出力され、ブラウザで確認できることを確認
- 本文に病院名・受診日・目的が正しく表示されることを確認
- http://localhost:5000/letter_openerにアクセスし、メール一覧が確認できることを確認

### 見ていただきたいこと
- コールバックの設計で
after_create / after_commit / after_create_commit のどれを使うべきか迷っています。


<img width="1059" height="508" alt="スクリーンショット 2025-09-07 11 32 43" src="https://github.com/user-attachments/assets/0064f1c4-9051-48dd-b5ab-e0939ccb89ef" />
