### PR TITLE
Sidekiq導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "binding_of_caller"
 gem "streamio-ffmpeg", "~> 3.0", ">= 3.0.2"
 gem "active_storage_validations"
 gem "image_processing", ">= 1.2"
-
+gem "sidekiq"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,8 @@ GEM
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
+    redis-client (0.25.2)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -418,6 +420,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (8.0.7)
+      connection_pool (>= 2.5.0)
+      json (>= 2.9.0)
+      logger (>= 1.6.2)
+      rack (>= 3.1.0)
+      redis-client (>= 0.23.2)
     smart_properties (1.17.0)
     solid_cable (3.0.8)
       actioncable (>= 7.2)
@@ -524,6 +532,7 @@ DEPENDENCIES
   rails-i18n
   rubocop-rails-omakase
   selenium-webdriver
+  sidekiq
   solid_cable
   solid_cache
   solid_queue

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,6 @@ module YorisoiNote2
     config.time_zone = "Tokyo" # タイムゾーンを東京に設定 録音機能で使用
     config.active_storage.variant_processor = :mini_magick
     # config.eager_load_paths << Rails.root.join("extras")
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379") }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  mount Sidekiq::Web => "/sidekiq" if Rails.env.development?
   devise_for :users # ユーザーのログイン・登録などに必要なルート
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "home#index"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: 1
+:queues:
+  - default
+  - mailers


### PR DESCRIPTION
## 概要
- Sidekiqを導入しました
  - `gem 'sidekiq'` を追加
  - ActiveJobのアダプタを`:sidekiq`に変更
  - Redis接続設定を`config/initializers/sidekiq.rb`に追加
  -`config/sidekiq.yml`にキュー設定を追加
  - 開発環境限定でSidekiq Web UI を`/sidekiq`にマウント

## 動作確認
- `redis-server`を起動
- `bundle exec sidekiq -C config/sidekiq.yml` を実行し、ジョブが処理されることを確認
- `deliver_later`経由でメールが非同期送信されることを確認
- http://localhost:5000/sidekiqにてWeb UI表示されることを確認

## レビューしてほしい点
- `sidekiq-cron`を導入し、定期ジョブの設定予定です。Sidekiq / Redisの基本設定に抜け漏れがないでしょうか。
- concurrency や queue の初期値（`default`, `mailers`）はこれで妥当か

## 今後の予定
- `sidekiq-cron`を導入して、リマインダーメールなどの定期ジョブの設定予定です
<img width="1477" height="805" alt="スクリーンショット 2025-09-09 22 41 09" src="https://github.com/user-attachments/assets/7185b210-d348-4191-83d1-dd32a80c3fcc" />
<img width="1477" height="805" alt="スクリーンショット 2025-09-09 22 41 21" src="https://github.com/user-attachments/assets/3babd1b3-4671-44c0-be1a-39b71938eb12" />
