### PR TITLE
プロフィール機能の実装（Profileモデル・編集画面・スタイル追加）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @use "recordings/recording";
 @use "recordings/wave";
 @use "documents_upload";
+@use "profile";

--- a/app/assets/stylesheets/documents_upload.scss
+++ b/app/assets/stylesheets/documents_upload.scss
@@ -251,33 +251,3 @@
   text-align: center;
   margin-top: 2rem;
 }
-
-// // レスポンシブデザイン
-// @media (max-width: 1200px) {
-//   .card {
-//     max-width: 960px;
-//     margin: 0 auto 1.5rem; // 中央寄せ
-//   }
-// }
-
-// @media (max-width: 992px) {
-//   .card {
-//     max-width: 720px;
-//     margin: 0 auto 1.5rem;
-//   }
-// }
-
-// @media (max-width: 768px) {
-//   .card {
-//     max-width: 100%;
-//     margin: 0 1rem 1.5rem; // 横に余白を少しだけ確保
-//   }
-
-//   .upload-area {
-//     padding: 2rem 1rem;
-//   }
-
-//   .preview-wrapper {
-//     min-height: 160px; // 枠を少し小さめに
-//   }
-// }

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,3 +1,6 @@
+@use "variables" as *;
+
+
 textarea.form-control {
   resize: vertical;
   min-height: 100px;

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,0 +1,20 @@
+textarea.form-control {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.form-select {
+  appearance: none;
+  background-color: $white;
+  border: 1px solid $border-color;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+
+
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 16 16' fill='%23666'><path d='M2 5l6 6 6-6'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 0.8rem;
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,27 @@
+class ProfilesController < ApplicationController
+  before_action :set_profile
+
+  def edit
+    @profile = current_user.profile || current_user.build_profile
+  end
+
+  def update
+    if @profile.update(profile_params)
+      redirect_to edit_profile_path, notice: "プロフィールを更新しました。"
+    else
+      flash.now[:error] = "更新できませんでした。"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+
+  private
+
+  def set_profile
+    @profile = current_user.profile || current_user.build_profile
+  end
+
+  def profile_params
+    params.expect(profile: [ :birthday, :gender, :height, :weight, :blood_type, :allergy_details, :medical_history, :current_medication ])
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,10 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+
+  validates :birthday, presence: true
+  validates :gender, presence: true
+  validates :height, :weight, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+
+  enum :gender, { male: 0, female: 1 }
+  BLOOD_TYPES = [ "A型", "B型", "O型", "AB型", "不明" ].freeze
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :question_selections, dependent: :destroy
   has_many :notifications, dependent: :destroy
 
+  has_one :profile, dependent: :destroy
+
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :encrypted_password, presence: true

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -7,8 +7,10 @@
 
 <div class="container">
   <div class="form-container">
-      <h2 class="form-title text-center text-pink">プロフィール</h2>
-      <% if @profile.errors.any? %>
+    <h2 class="form-title text-center text-pink">プロフィール</h2>
+       <p class="text-center">登録内容を変更できます</p>
+
+    <% if @profile.errors.any? %>
       <div class="error-messages">
         <ul>
           <% @profile.errors.full_messages.each do |message| %>
@@ -16,52 +18,57 @@
           <% end %>
         </ul>
       </div>
-     <% end %>
+    <% end %>
 
-  <%= form_with(model: @profile, url: profile_path, method: :patch, local: true) do |f| %>
-    <div>
-      <%= f.label :birthday, "生年月日" %>
-      <%= f.date_field :birthday, class: 'form-control' %>
-    </div>
+    <%= form_with(model: @profile, url: profile_path, method: :patch, local: true) do |f| %>
+      <div class="mb-3">
+        <label class="form_label">名前</label>
+        <p class="form-control-plaintext"><%= current_user.name %></p>
+      </div>
 
-    <div>
-      <%= f.label :gender, "性別" %>
-      <%= f.select :gender, Profile.genders.keys.map { |k, v| [ I18n.t("enums.profile.gender.#{k}"), k ] }, {}, { class: 'form-select' } %>
-    </div>
+      <div>
+        <%= f.label :birthday, "生年月日" %>
+        <%= f.date_field :birthday, class: 'form-control' %>
+      </div>
 
-    <div>
-       <%= f.label :height, "身長(cm)" %>
-       <%= f.number_field :height, class: 'form-control' %>
-    </div>
+      <div>
+        <%= f.label :gender, "性別" %>
+        <%= f.select :gender, Profile.genders.keys.map { |k, v| [ I18n.t("enums.profile.gender.#{k}"), k ] }, {}, { class: 'form-select' } %>
+      </div>
 
-    <div>
-      <%= f.label :weight, "体重(kg)" %>
-      <%= f.number_field :weight, class: 'form-control' %>
-    </div>
+      <div>
+        <%= f.label :height, "身長(cm)" %>
+        <%= f.number_field :height, class: 'form-control' %>
+      </div>
 
-    <div>
-      <%= f.label :blood_type, "血液型" %>
-      <%= f.select :blood_type, Profile::BLOOD_TYPES,{},{ class: 'form-select' } %>
-    </div>
+      <div>
+        <%= f.label :weight, "体重(kg)" %>
+        <%= f.number_field :weight, class: 'form-control' %>
+      </div>
 
-    <div>
-      <%= f.label :allergy_details, "アレルギー歴" %>
-      <%= f.text_area :allergy_details, class: "form-control" %>
-    </div>
+      <div>
+        <%= f.label :blood_type, "血液型" %>
+        <%= f.select :blood_type, Profile::BLOOD_TYPES, {}, { class: 'form-select' } %>
+      </div>
 
-    <div>
-      <%= f.label :medical_history, "既往歴" %>
-      <%= f.text_area :medical_history, class: "form-control" %>
-    </div>
+      <div>
+        <%= f.label :allergy_details, "アレルギー歴" %>
+        <%= f.text_area :allergy_details, class: "form-control" %>
+      </div>
 
-    <div>
-      <%= f.label :current_medication, "内服薬" %>
-      <%= f.text_area :current_medication, class: "form-control" %>
-    </div>
+      <div>
+        <%= f.label :medical_history, "既往歴" %>
+        <%= f.text_area :medical_history, class: "form-control" %>
+      </div>
 
-    <div class="text-center mt-4">
-      <%= f.submit "保存", class: "btn btn-outline-pink btn-lg px-5 py-3" %>
-    </div>
-  <% end %>
+      <div>
+        <%= f.label :current_medication, "内服薬" %>
+        <%= f.text_area :current_medication, class: "form-control" %>
+      </div>
+
+      <div class="text-center mt-4">
+        <%= f.submit "保存", class: "btn btn-outline-pink btn-lg px-5 py-3" %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,67 @@
+<div class="d-flex justify-content-start">
+  <%= link_to visits_path, class: "btn btn-outline-secondary d-flex align-items-center back-button" do %>
+    <i class="bi bi-arrow-left-circle-fill me-2"></i>
+    戻る
+  <% end %>
+</div>
+
+<div class="container">
+  <div class="form-container">
+      <h2 class="form-title text-center text-pink">プロフィール</h2>
+      <% if @profile.errors.any? %>
+      <div class="error-messages">
+        <ul>
+          <% @profile.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+     <% end %>
+
+  <%= form_with(model: @profile, url: profile_path, method: :patch, local: true) do |f| %>
+    <div>
+      <%= f.label :birthday, "生年月日" %>
+      <%= f.date_field :birthday, class: 'form-control' %>
+    </div>
+
+    <div>
+      <%= f.label :gender, "性別" %>
+      <%= f.select :gender, Profile.genders.keys.map { |k, v| [ I18n.t("enums.profile.gender.#{k}"), k ] }, {}, { class: 'form-select' } %>
+    </div>
+
+    <div>
+       <%= f.label :height, "身長(cm)" %>
+       <%= f.number_field :height, class: 'form-control' %>
+    </div>
+
+    <div>
+      <%= f.label :weight, "体重(kg)" %>
+      <%= f.number_field :weight, class: 'form-control' %>
+    </div>
+
+    <div>
+      <%= f.label :blood_type, "血液型" %>
+      <%= f.select :blood_type, Profile::BLOOD_TYPES,{},{ class: 'form-select' } %>
+    </div>
+
+    <div>
+      <%= f.label :allergy_details, "アレルギー歴" %>
+      <%= f.text_area :allergy_details, class: "form-control" %>
+    </div>
+
+    <div>
+      <%= f.label :medical_history, "既往歴" %>
+      <%= f.text_area :medical_history, class: "form-control" %>
+    </div>
+
+    <div>
+      <%= f.label :current_medication, "内服薬" %>
+      <%= f.text_area :current_medication, class: "form-control" %>
+    </div>
+
+    <div class="text-center mt-4">
+      <%= f.submit "保存", class: "btn btn-outline-pink btn-lg px-5 py-3" %>
+    </div>
+  <% end %>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,21 +25,57 @@ ja:
           patient_card: 診察券
           other: その他
 
-    errors:
-      messages:
-        record_invalid: 'バリデーションに失敗しました: %{errors}'
-        restrict_dependent_destroy:
-          has_one: "%{record}が存在しているので削除できません"
-          has_many: "%{record}が存在しているので削除できません"
-      models:
-        visit:
-          attributes:
-            hospital_name:
-              taken: "は同じ受診日、時間、目的ですでに登録されています。"
-        document:
-          attributes:
-            doc_type:
-              blank: "を選択してください"
+  enums:
+    profile:
+      gender:
+        male: 男性
+        female: 女性
+
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      record_invalid: 'バリデーションに失敗しました: %{errors}'
+      restrict_dependent_destroy:
+        has_one: "%{record}が存在しているので削除できません"
+        has_many: "%{record}が存在しているので削除できません"
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+    models:
+      visit:
+        attributes:
+          hospital_name:
+            taken: "は同じ受診日、時間、目的ですでに登録されています。"
+      document:
+        attributes:
+          doc_type:
+            blank: "を選択してください"
   date:
     abbr_day_names:
     - 日
@@ -139,38 +175,6 @@ ja:
       day: 日
       month: 月
       year: 年
-  errors:
-    format: "%{attribute}%{message}"
-    messages:
-      accepted: を受諾してください
-      blank: を入力してください
-      confirmation: と%{attribute}の入力が一致しません
-      empty: を入力してください
-      equal_to: は%{count}にしてください
-      even: は偶数にしてください
-      exclusion: は予約されています
-      greater_than: は%{count}より大きい値にしてください
-      greater_than_or_equal_to: は%{count}以上の値にしてください
-      inclusion: は一覧にありません
-      invalid: は不正な値です
-      less_than: は%{count}より小さい値にしてください
-      less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: 'バリデーションに失敗しました: %{errors}'
-      not_a_number: は数値で入力してください
-      not_an_integer: は整数で入力してください
-      odd: は奇数にしてください
-      other_than: は%{count}以外の値にしてください
-      present: は入力しないでください
-      required: を入力してください
-      taken: はすでに存在します
-      too_long: は%{count}文字以内で入力してください
-      too_short: は%{count}文字以上で入力してください
-      wrong_length: は%{count}文字で入力してください
-    template:
-      body: 次の項目を確認してください
-      header:
-        one: "%{model}にエラーが発生しました"
-        other: "%{model}に%{count}個のエラーが発生しました"
   helpers:
     select:
       prompt: 選択してください

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
   root to: "home#index"
 
+  resource :profile, only: [ :edit, :update ]
+
   # 診察記録と紐づく予定
   resources :visits, except: [ :show ] do
     collection do

--- a/db/migrate/20250916013253_create_profiles.rb
+++ b/db/migrate/20250916013253_create_profiles.rb
@@ -1,0 +1,17 @@
+class CreateProfiles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :birthday, null: false
+      t.integer :gender, null: false
+      t.integer :height
+      t.integer :weight
+      t.string :blood_type, default: "不明"
+      t.text :allergy_details, default: ""
+      t.text :medical_history, default: ""
+      t.text :current_medication, default: ""
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_11_011641) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_16_013253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,6 +69,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_11_011641) do
     t.bigint "visit_id", null: false
     t.index ["user_id"], name: "index_notifications_on_user_id"
     t.index ["visit_id"], name: "index_notifications_on_visit_id"
+  end
+
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "birthday", null: false
+    t.integer "gender", null: false
+    t.integer "height"
+    t.integer "weight"
+    t.string "blood_type", default: "不明"
+    t.text "allergy_details", default: ""
+    t.text "medical_history", default: ""
+    t.text "current_medication", default: ""
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "question_categories", force: :cascade do |t|
@@ -148,6 +163,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_11_011641) do
   add_foreign_key "documents", "visits"
   add_foreign_key "notifications", "users"
   add_foreign_key "notifications", "visits"
+  add_foreign_key "profiles", "users"
   add_foreign_key "question_selections", "questions"
   add_foreign_key "question_selections", "users"
   add_foreign_key "question_selections", "visits"


### PR DESCRIPTION
## 概要
- プロフィール機能を追加しました。
- Userに1対1で紐づくProfileモデルを作成し、編集・更新が可能になっています。

## 主な変更点
- profilesテーブルを新規作成（user_id, birthday, gender, height, weight, blood_type, allergy_details, medical_history, current_medication）
- Profileモデルを追加し、バリデーションとenumを設定
- Userモデルに `has_one :profile` を追加
- ProfilesController（edit/update）を追加し、current_userに紐づくプロフィールを編集可能に
- プロフィール編集画面（edit.html.erb）を実装（ユーザー名表示・入力フォーム追加）
- SCSSを追加（profile.scss: textarea, select のデザイン）
- ja.ymlにenum翻訳（gender）を追加
- routes.rbに `resource :profile, only: [:edit, :update]` を追加

## 確認方法
- `/profile/edit` にアクセスし、プロフィール編集フォームが表示されることを確認
- 入力後「保存」でプロフィールが更新されることを確認
- バリデーションエラー時にエラーメッセージが表示されることを確認