### PR TITLE
ユーザー登録情報編集画面のUI改善とアカウント削除機能の追加

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,58 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container d-flex align-items-center justify-content-center min-vh-100">
+  <div class="card shadow p-4 login-card">
+    <div class="text-center mb-4">
+      <h2 class="text-pink">アカウント情報の編集</h2>
+      <p>登録内容を変更できます</p>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_with model: resource, url: registration_path(resource_name), scope: resource_name, local: true, data: { turbo: false }, html: { method: :put } do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="mb-3">
+        <%= f.label :email, 'メールアドレス', class: 'form-label' %>
+        <%= f.email_field :email, autofocus: true, class: 'form-control', required: true %>
+      </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div class="alert alert-warning">
+          現在、確認待ちのメールアドレス: <%= resource.unconfirmed_email %>
+        </div>
+      <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <div class="mb-3">
+        <%= f.label :password, '新しいパスワード（空欄の場合は変更しません）', class: 'form-label' %>
+        <%= f.password_field :password, class: 'form-control', autocomplete: "new-password" %>
+        <% if @minimum_password_length %>
+          <small class="text-muted"><%= @minimum_password_length %>文字以上</small>
+        <% end %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :password_confirmation, '新しいパスワード（確認用）', class: 'form-label' %>
+        <%= f.password_field :password_confirmation, class: 'form-control', autocomplete: "new-password" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :current_password, '現在のパスワード（必須）', class: 'form-label' %>
+        <%= f.password_field :current_password, class: 'form-control', autocomplete: "current-password", required: true %>
+      </div>
+
+      <div class="d-grid mb-3">
+        <%= f.submit "更新する", class: "btn btn-pink btn-lg" %>
+      </div>
     <% end %>
+
+    <hr class="my-4">
+
+    <div class="text-center mb-3">
+      <%= button_to "アカウント削除", registration_path(resource_name),
+          method: :delete,
+          data: { confirm: "本当に削除しますか？" },
+          class: "btn btn-outline-danger w-100" %>
+    </div>
+
+    <div class="text-center">
+      <%= link_to "戻る", root_path, class: "btn btn-outline-secondary w-100" %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,16 +42,16 @@
         </button>
         <p class="mb-0">ようこそ、<strong><%= current_user.name %></strong>さん</p>
       </div>
-      <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'btn btn-pink btn-logout' %>
+      <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'btn btn-pink btn-logout' %>
     </div>
 
     <nav id="sidebarMenu" class="sidebar">
       <div class="inner">
         <ul class="sidebar-nav">
-          <li><%= link_to "スケジュール", visits_path %></li>
-          <li><%= link_to "質問を選ぶ", "#" %></li>
-          <li><%= link_to "プロフィール", "#" %></li>
-          <li><%= link_to "設定（未実装）", "#" %></li>
+          <li><%= link_to "スケジュールを確認する", visits_path %></li>
+          <li><%= link_to "受診に関する画像を確認する", visit_documents_path(current_user.visits.last) if current_user.visits.any? %></li>
+          <li><%= link_to "プロフィールを見る", edit_profile_path %></li>
+          <li><%= link_to "パスワードを変更する", edit_user_registration_path %></li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
- Deviseのユーザー編集画面のUIを作成しました  
  - 入力フィールドにform-controlを適用  
  - ラベルを日本語化 & 適切なクラス付与  
  - ボタンを見やすいスタイルに調整  
- アカウント削除ボタンを画面下部に追加し、削除確認ダイアログを表示するようにしました  
- サイドバーのナビゲーションも調整し、ログアウトボタンのturbo動作を無効化しました
