### PR TITLE
デプロイ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@
 !/app/assets/builds/.keep
 
 /node_modules
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "active_storage_validations"
 gem "image_processing", ">= 1.2"
 gem "sidekiq"
 gem "sidekiq-cron", "~> 2.3"
+gem "aws-sdk-s3", require: false
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,25 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1164.0)
+    aws-sdk-core (3.233.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.113.0)
+      aws-sdk-core (~> 3, >= 3.231.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.199.0)
+      aws-sdk-core (~> 3, >= 3.231.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -213,6 +232,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    jmespath (1.6.2)
     json (2.13.2)
     kamal (2.7.0)
       activesupport (>= 7.0)
@@ -525,6 +545,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_validations
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml
+release: bundle exec rake db:migrate

--- a/app.json
+++ b/app.json
@@ -1,0 +1,25 @@
+{
+  "name": "yorisoi-note-app",
+  "description": "A Rails 8 demo app with Sidekiq and Redis",
+  "keywords": ["rails", "heroku", "sidekiq", "redis"],
+  "website": "https://yorisoi-note-app.herokuapp.com",
+  "repository": "https://github.com/mori-1122/yorisoi-note-app",
+  "env": {
+    "RAILS_MASTER_KEY": {
+      "description": "Rails credentials master key required for production"
+    },
+    "REDIS_URL": {
+      "description": "Redis connection URL (set automatically by Heroku Redis)"
+    }
+  },
+  "addons": [
+    "heroku-postgresql:essential-0",
+    "heroku-redis:mini"
+  ],
+  "buildpacks": [
+    { "url": "heroku/ruby" }
+  ],
+  "scripts": {
+    "postdeploy": "bundle exec rake db:migrate"
+  }
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,11 +11,15 @@ module YorisoiNote2
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
+    if Rails.env.development? || Rails.env.test?
+      Dotenv::Railtie.load
+    end
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
-    config.i18n.default_locale = :ja # #日本語にする
+    config.i18n.default_locale = :ja # 日本語にする
     config.action_dispatch.allow_browser = true
     config.action_mailer.default_url_options = { host: "localhost", port: 5000 }
     # Configuration for the application, engines, and railties goes here.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,13 +6,12 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon:
+  service: S3
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: us-east-1
+  bucket: your_own_bucket-<%= Rails.env %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,10 +8,10 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: us-east-1
-  bucket: your_own_bucket-<%= Rails.env %>
+  access_key_id: <%= ENV['AWS_ACCESS_KEY'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>
+  region: ap-northeast-1
+  bucket: <%= ENV['AWS_BUCKET_NAME'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
# 概要
本番環境をHerokuにデプロイするための設定を追加・修正しました。Active Storageの保存先をS3に切り替え、認証情報をcredentialsから環境変数に移行しています。

## 主な変更点

### **Gemfile**
- `aws-sdk-s3` を追加し、S3 アップロードに対応

### **storage.yml**
- S3 用の `amazon` サービスを有効化
- `credentials` 依存を廃止し、`ENV` 経由の設定に変更
- リージョンを `ap-northeast-1` に修正

### **config/environments/production.rb**
- ActiveStorage の保存先を `:amazon` に変更

### **config/application.rb**
- 開発・テスト環境のみ `.env` を読み込むよう `dotenv` を設定
- コメント修正（日本語化）

### **.gitignore**
- `.env` を追加し、リポジトリに含めないように設定

### **app.json**
- Heroku デプロイ用の設定を追加（Postgres, Redis, RAILS_MASTER_KEY 等）