### PR TITLE
SidekiqのRedis接続設定を修正・リファクタリング

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,15 +61,18 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: "example.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
+  config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    domain: "gmail.com",
-    port: 587,
-    user_name: ENV["MAILER_SENDER"],
-    password: ENV["MAILER_PASSWORD"],
-    authentication: "plain",
-    enable_starttls_auto: true
-  }
+  user_name: "apikey",
+  password: ENV["SENDGRID_API_KEY"],
+  domain: "heroku.com", # 将来独自ドメイン
+  address: "smtp.sendgrid.net",
+  port: 587,
+  authentication: :plain,
+  enable_starttls_auto: true
+}
+
+  config.action_mailer.default_url_options = { host: "yorisoi-note-app.herokuapp.com", protocol: "https" }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,15 @@
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379") }
+  config.redis = {
+    url: ENV.fetch("REDIS_URL", "redis://localhost:6379"),
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV.fetch("REDIS_URL", "redis://localhost:6379") }
+  config.redis = {
+    url: ENV.fetch("REDIS_URL", "redis://localhost:6379"),
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
 end
 
 # sidekiq-cronの設定

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
-redis_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+# REDIS_TLS_URL を優先的に利用し、なければ REDIS_URL、それもなければローカルを使う
+redis_url = ENV["REDIS_TLS_URL"] || ENV.fetch("REDIS_URL", "redis://localhost:6379")
 
 Sidekiq.configure_server do |config|
   config.redis = {

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,13 +1,15 @@
+redis_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: ENV.fetch("REDIS_URL", "redis://localhost:6379"),
+    url: redis_url,
     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: ENV.fetch("REDIS_URL", "redis://localhost:6379"),
+    url: redis_url,
     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,9 +8,9 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV['AWS_ACCESS_KEY'] %>
-  secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>
-  region: ap-northeast-1
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['AWS_REGION'] %>
   bucket: <%= ENV['AWS_BUCKET_NAME'] %>
 
 # Remember not to checkin your GCS keyfile to a repository


### PR DESCRIPTION
### 概要
Heroku Key-Value Store (Redis) へのTLS接続で発生していた
「certificate verify failed」エラーを解消するため、SidekiqのRedis設定を修正しました。

- `ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }` を追加し、自己署名証明書による接続失敗を回避
- `REDIS_URL` を共通変数 `redis_url` にまとめてサーバー／クライアント両方で再利用するようリファクタリング
- Heroku環境変数 SENDGRID_API_KEYを利用するよう修正
- default_url_optionsをHerokuアプリのURLに設定