### PR TITLE
VisitモデルのRSpecテストとFactoryの追加

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,13 +1,3 @@
-# == Schema Information
-#
-# Table name: departments
-#
-#  id         :integer          not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#
-
 class Department < ApplicationRecord
   has_many :visits
 

--- a/spec/factories/department.rb
+++ b/spec/factories/department.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :department do
+    name { "内科" }
+  end
+end

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :visit do
+    association :user
+    association :department
+
+    visit_date { Date.tomorrow }
+    hospital_name { "東京病院" }
+    purpose { "検査" }
+    appointed_at { 1.hour.from_now }
+  end
+end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Visit, type: :model do
+  let!(:user) { create(:user) }
+  let!(:department) { create(:department, name: "内科") }
+
+  context "有効な場合" do
+    it "必須項目が揃っていれば有効である" do
+      visit = build(:visit, user: user, department: department)
+      expect(visit).to be_valid
+    end
+  end
+
+  context "無効な場合" do
+    it "診療科がなければ無効である" do
+      visit = build(:visit, user: user, department: nil)
+      visit.valid?
+      expect(visit.errors[:department]).to include("を入力してください")
+    end
+
+    it "受診予定日が空では保存できない" do
+      visit = build(:visit, user: user, department: department, visit_date: nil)
+      visit.valid?
+      expect(visit.errors[:visit_date]).to include("を入力してください")
+    end
+
+    it "受診予定日が過去の日付では保存できない" do
+      visit = build(:visit, user: user, department: department, visit_date: Date.yesterday)
+      visit.valid?
+      expect(visit.errors[:visit_date]).to include("は、今日以降の日付を指定してください。")
+    end
+
+    it "受診予定時間が過去では保存できない" do
+      visit = build(:visit, user: user, department: department, visit_date: Date.yesterday, appointed_at: 1.day.ago)
+      visit.valid?
+      expect(visit.errors[:appointed_at]).to include("は、現在以降の日時を指定してください。")
+    end
+
+    it "同じユーザーで同じ日、同じ時間は重複登録できない" do
+      create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00")
+      new_visit = build(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00")
+      new_visit.valid?
+      expect(new_visit.errors[:appointed_at]).to include("は、すでに他の予定と重複して登録されています。")
+    end
+  end
+
+  describe "日時結合の処理" do
+    it "受診日と受診予約時間が結合される" do
+      visit = build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: "10:00")
+      visit.valid?
+      expect(visit.appointed_at.strftime("%H:%M")).to eq("10:00")
+    end
+  end
+
+  describe "通知メールの作成処理" do
+    it "受診予定を登録すると即時通知と前日通知が作成される" do
+      visit = create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00")
+      visit.create_notifications
+
+      expect(visit.notifications.count).to eq(2)
+
+      immediate = visit.notifications.find_by(title: "【受診予定を新規登録しました】東京病院")
+      reminder = visit.notifications.find_by(title: "【受診に関するリマインド】東京病院")
+
+      # 即時通知
+      expect(immediate).not_to be_nil
+      expect(immediate.due_date).to eq(Date.current)
+      expect(immediate.is_sent).to be(false) # レコードを作ったけどまだ送っていないことを期待する
+
+
+      # 前日通知
+      expect(reminder).not_to be_nil
+      expect(reminder.due_date).to eq(Date.tomorrow - 1.day)
+      expect(reminder.is_sent).to be(false)
+    end
+  end
+end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -1,77 +1,92 @@
 require 'rails_helper'
 
 RSpec.describe Visit, type: :model do
-  let!(:user) { create(:user) }
-  let!(:department) { create(:department, name: "内科") }
+  let(:user) { create(:user) }
+  let(:department) { create(:department, name: "内科") }
 
-  context "有効な場合" do
-    it "必須項目が揃っていれば有効である" do
-      visit = build(:visit, user: user, department: department)
-      expect(visit).to be_valid
+  context "必須項目が揃っている場合" do
+    let(:visit) { build(:visit, user: user, department: department) }
+
+    it "有効である" do
+      expect(visit.valid?).to be true
     end
   end
 
-  context "無効な場合" do
-    it "診療科がなければ無効である" do
-      visit = build(:visit, user: user, department: nil)
-      visit.valid?
+  context "診療科がない場合" do
+    let(:visit) { build(:visit, user: user, department: nil) }
+
+    it "無効である" do
+      expect(visit.valid?).to be false
       expect(visit.errors[:department]).to include("を入力してください")
     end
+  end
 
-    it "受診予定日が空では保存できない" do
-      visit = build(:visit, user: user, department: department, visit_date: nil)
-      visit.valid?
+  context "受診予定日が空の場合" do
+    let(:visit) { build(:visit, user: user, department: department, visit_date: nil) }
+
+    it "無効である" do
+      expect(visit.valid?).to be false
       expect(visit.errors[:visit_date]).to include("を入力してください")
     end
+  end
 
-    it "受診予定日が過去の日付では保存できない" do
-      visit = build(:visit, user: user, department: department, visit_date: Date.yesterday)
-      visit.valid?
+  context "受診予定日が過去の日付の場合" do
+    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.yesterday) }
+
+    it "無効である" do
+      expect(visit.valid?).to be false
       expect(visit.errors[:visit_date]).to include("は、今日以降の日付を指定してください。")
     end
+  end
 
-    it "受診予定時間が過去では保存できない" do
-      visit = build(:visit, user: user, department: department, visit_date: Date.yesterday, appointed_at: 1.day.ago)
-      visit.valid?
+  context "受診予定時間が過去の場合" do
+    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.yesterday, appointed_at: 1.day.ago) }
+
+    it "無効である" do
+      expect(visit.valid?).to be false
       expect(visit.errors[:appointed_at]).to include("は、現在以降の日時を指定してください。")
     end
+  end
 
-    it "同じユーザーで同じ日、同じ時間は重複登録できない" do
-      create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00")
-      new_visit = build(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00")
-      new_visit.valid?
+  context "同じユーザーで同じ日・同じ時間に重複登録した場合" do
+    let!(:existing_visit) { create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00") }
+    let(:new_visit) { build(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00") }
+
+    it "無効である" do
+      expect(new_visit.valid?).to be false
       expect(new_visit.errors[:appointed_at]).to include("は、すでに他の予定と重複して登録されています。")
     end
   end
 
-  describe "日時結合の処理" do
-    it "受診日と受診予約時間が結合される" do
-      visit = build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: "10:00")
-      visit.valid?
+  context "受診日と受診予約時間が結合される場合" do
+    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: "10:00") }
+
+    it "有効である" do
+      expect(visit.valid?).to be true
       expect(visit.appointed_at.strftime("%H:%M")).to eq("10:00")
     end
   end
 
-  describe "通知メールの作成処理" do
+  context "通知メールの作成処理" do
+    let(:visit) { create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00") }
+
     it "受診予定を登録すると即時通知と前日通知が作成される" do
-      visit = create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00")
       visit.create_notifications
 
       expect(visit.notifications.count).to eq(2)
 
       immediate = visit.notifications.find_by(title: "【受診予定を新規登録しました】東京病院")
-      reminder = visit.notifications.find_by(title: "【受診に関するリマインド】東京病院")
+      reminder  = visit.notifications.find_by(title: "【受診に関するリマインド】東京病院")
 
       # 即時通知
       expect(immediate).not_to be_nil
       expect(immediate.due_date).to eq(Date.current)
-      expect(immediate.is_sent).to be(false) # レコードを作ったけどまだ送っていないことを期待する
-
+      expect(immediate.is_sent).to be false
 
       # 前日通知
       expect(reminder).not_to be_nil
       expect(reminder.due_date).to eq(Date.tomorrow - 1.day)
-      expect(reminder.is_sent).to be(false)
+      expect(reminder.is_sent).to be false
     end
   end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Visit, type: :model do
   end
 
   context "受診予定時間が過去の場合" do
-    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.yesterday, appointed_at: 1.day.ago) }
+    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: 1.day.ago) }
 
     it "無効である" do
       expect(visit.valid?).to be false
@@ -49,8 +49,8 @@ RSpec.describe Visit, type: :model do
   end
 
   context "同じユーザーで同じ日・同じ時間に重複登録した場合" do
-    let!(:existing_visit) { create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00") }
-    let(:new_visit) { build(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: "10:00") }
+    let!(:existing_visit) { create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: Time.zone.parse("10:00")) }
+    let(:new_visit) { build(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: Time.zone.parse("10:00")) }
 
     it "無効である" do
       expect(new_visit.valid?).to be false
@@ -64,6 +64,23 @@ RSpec.describe Visit, type: :model do
     it "有効である" do
       expect(visit.valid?).to be true
       expect(visit.appointed_at.strftime("%H:%M")).to eq("10:00")
+    end
+  end
+
+  context "受診予定日が今日の場合" do
+    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: "10:00") }
+
+    it "有効である" do
+      expect(visit.valid?).to be true
+    end
+  end
+
+  context "受診予定時間を現在時刻で登録した場合" do
+    let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: Time.zone.now) }
+
+    it "無効である" do
+      expect(visit.valid?).to be false
+      expect(visit.errors[:appointed_at]).to include("は、現在以降の日時を指定してください。")
     end
   end
 


### PR DESCRIPTION
## 概要
Visitモデルに対してRSpecを用いたモデルテストを追加しました。
あわせてFactoryBotのファクトリを作成し、テストデータ生成を簡潔に記述できるようにしています。

## 主な変更点
- Visitモデル用のFactoryBotファクトリを追加
- DepartmentモデルのFactoryを追加（name: "内科"）
- Visitモデルのバリデーション・独自処理に関するRSpecを実装
  - 必須項目の検証
  - 過去日付/過去時間での登録不可の検証
  - 重複登録不可の検証
  - 日付と時間の結合処理の検証
  - 通知作成処理（即時通知・前日通知）の検証
- 不要なコメントを削除し、モデル定義を整理
