### PR TITLE
Userモデルのバリデーションテストをletとcontextで整理

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,35 +5,54 @@ RSpec.describe User, type: :model do
     context "有効な場合" do
       let(:user) { build(:user) }
 
-      it "名前、メールアドレス、パスワードが入力されていれば有効である" do
-        expect(user).to be_valid
+      it "バリデーションを通る" do
+        expect(user.valid?).to be true
       end
     end
 
-    context "登録できない場合" do
-      it "名前が空では無効である" do
-        user = build(:user, name: "")
-        user.valid?
+    context "名前が空の場合" do
+      let(:user) { build(:user, name: "") }
+
+      it "無効である" do
+        expect(user.valid?).to be false
         expect(user.errors[:name]).to include("を入力してください")
       end
+    end
 
-      it "メールアドレスが空の場合は無効である" do
-        user = build(:user, email: "")
-        user.valid?
+    context "メールアドレスが空の場合" do
+      let(:user) { build(:user, email: "") }
+
+      it "無効である" do
+        expect(user.valid?).to be false
         expect(user.errors[:email]).to include("を入力してください")
       end
+    end
 
-      it "パスワードが空の場合は無効である" do
-        user = build(:user, password: "")
-        user.valid?
+    context "パスワードが空の場合" do
+      let(:user) { build(:user, password: "") }
+
+      it "無効である" do
+        expect(user.valid?).to be false
         expect(user.errors[:password]).to include("を入力してください")
       end
+    end
 
-      it "メールアドレスが重複している場合は無効である" do
-        create(:user, email: "test@example.com")
-        user = build(:user, email: "test@example.com")
-        user.valid?
-        expect(user.errors[:email]).to include("はすでに存在します")
+    context "メールアドレスの形式が不正な場合" do
+      let(:user) { build(:user, email: "090-1111-2222") }
+
+      it "無効である" do
+        expect(user.valid?).to be false
+        expect(user.errors[:email]).to include("は不正な値です")
+      end
+    end
+
+    context "メールアドレスが重複している場合" do
+      let!(:user1) { create(:user, email:"test@example.com") }
+      let(:user2) { build(:user, email:"test@example.com") }
+
+      it "無効である" do
+        expect(user2.valid?).to be false
+        expect(user2.errors[:email]).to include("はすでに存在します")
       end
     end
   end


### PR DESCRIPTION
### 変更内容
- Userモデルのバリデーションテストを整理
- letを導入してテスト対象を明示的に管理
- contextを追加して条件ごとにグルーピング
- テスト名を「〜の場合」「無効である」などに統一し、可読性を向上
- expect(user.valid?).to be true/false に統一して検証

### 目的
- テストコードの可読性・メンテナンス性を向上させるため
- バリデーションエラーの条件を明確に切り分け、将来の改修で壊れにくくするため

### 動作確認
bundle exec rspec spec/models/user_spec.rb を実行し、全6件のテストが成功することを確認済み