### PR TITLE
pumaの更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "propshaft"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", ">= 5.0"
+gem "puma"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (7.0.2)
+    puma (7.0.4)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -577,7 +577,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-rails
-  puma (>= 5.0)
+  puma
   rails (~> 8.0.2)
   rails-i18n
   rspec-rails


### PR DESCRIPTION
### 変更内容
- Pumaのバージョンを 7.0.2 → 7.0.4 に更新
- GemfileのPumaの指定を緩和（puma (>= 5.0) → puma）

### 背景
Heroku デプロイ時に以下のエラーが発生していた
```
Your application is using Puma 7.0.2.
This has a known issue with the `PUMA_PERSISTENT_TIMEOUT` environment variable.
Please upgrade your application to Puma 7.0.3+.
```
- デプロイが失敗していたため、Pumaを修正バージョンへアップデートした。