### PR TITLE
NotificationモデルとVisitモデルの通知関連テストを追加

### DIFF
--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :notification do
+    association :user
+    association :visit
+    title { "テスト通知" }
+    due_date { Date.today }
+    is_sent { false }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     name { "田中太郎" }
-    email { "test@example.com" }
+    sequence(:email) { |n| "test#{n}@example.com" }
     password { "password" }
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  describe "バリデーション" do
+    context "有効な場合" do
+      let(:notification) { build(:notification) }
+
+      it "バリデーションを通る" do
+        expect(notification.valid?).to be true
+      end
+    end
+
+    context "タイトルが空の場合" do
+      let(:notification) { build(:notification, title: nil) }
+
+      it "無効である" do
+        expect(notification.valid?).to be false
+        expect(notification.errors[:title]).to include("を入力してください")
+      end
+    end
+
+    context "受診予定日が空の場合" do
+      let(:notification) { build(:notification, due_date: nil) }
+
+      it "無効である" do
+        expect(notification.valid?).to be false
+        expect(notification.errors[:due_date]).to include("を入力してください")
+      end
+    end
+
+    context "ユーザーが紐づいていない場合" do
+      let(:notification) { build(:notification, user: nil) }
+
+      it "無効である" do
+        expect(notification.valid?).to be false
+        expect(notification.errors[:user]).to include("を入力してください")
+      end
+    end
+
+    context "受診の予定が紐ついていない場合" do
+      let(:notification) { build(:notification, visit: nil) }
+
+      it "無効である" do
+        expect(notification.valid?).to be false
+        expect(notification.errors[:visit]).to include("を入力してください")
+      end
+    end
+
+    context "is_sent のデフォルト値がfalseである場合" do
+      let(:notification) { create(:notification) }
+
+      it "falseである" do
+        expect(notification.is_sent).to be false
+      end
+    end
+  end
+end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Visit, type: :model do
   context "必須項目が揃っている場合" do
     let(:visit) { build(:visit, user: user, department: department) }
 
-    it "有効である" do
+    it "受診予定を登録できる" do
       expect(visit.valid?).to be true
     end
   end
@@ -15,7 +15,7 @@ RSpec.describe Visit, type: :model do
   context "診療科がない場合" do
     let(:visit) { build(:visit, user: user, department: nil) }
 
-    it "無効である" do
+    it "診療科がないと登録できない" do
       expect(visit.valid?).to be false
       expect(visit.errors[:department]).to include("を入力してください")
     end
@@ -24,7 +24,7 @@ RSpec.describe Visit, type: :model do
   context "受診予定日が空の場合" do
     let(:visit) { build(:visit, user: user, department: department, visit_date: nil) }
 
-    it "無効である" do
+    it "受診予定日がないと登録できない" do
       expect(visit.valid?).to be false
       expect(visit.errors[:visit_date]).to include("を入力してください")
     end
@@ -33,7 +33,7 @@ RSpec.describe Visit, type: :model do
   context "受診予定日が過去の日付の場合" do
     let(:visit) { build(:visit, user: user, department: department, visit_date: Date.yesterday) }
 
-    it "無効である" do
+    it "受診予定日は今日以降でなければ登録できない" do
       expect(visit.valid?).to be false
       expect(visit.errors[:visit_date]).to include("は、今日以降の日付を指定してください。")
     end
@@ -42,7 +42,7 @@ RSpec.describe Visit, type: :model do
   context "受診予定時間が過去の場合" do
     let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: 1.day.ago) }
 
-    it "無効である" do
+    it "受診予定日は現時点以降でなければ登録できない" do
       expect(visit.valid?).to be false
       expect(visit.errors[:appointed_at]).to include("は、現在以降の日時を指定してください。")
     end
@@ -52,7 +52,7 @@ RSpec.describe Visit, type: :model do
     let!(:existing_visit) { create(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: Time.zone.parse("10:00")) }
     let(:new_visit) { build(:visit, user: user, department: department, visit_date: Date.tomorrow, appointed_at: Time.zone.parse("10:00")) }
 
-    it "無効である" do
+    it "同じ日時の受診予定は重複して登録できない" do
       expect(new_visit.valid?).to be false
       expect(new_visit.errors[:appointed_at]).to include("は、すでに他の予定と重複して登録されています。")
     end
@@ -61,7 +61,7 @@ RSpec.describe Visit, type: :model do
   context "受診日と受診予約時間が結合される場合" do
     let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: "10:00") }
 
-    it "有効である" do
+    it "受診日と時刻を組み合わせて登録できる" do
       expect(visit.valid?).to be true
       expect(visit.appointed_at.strftime("%H:%M")).to eq("10:00")
     end
@@ -70,7 +70,7 @@ RSpec.describe Visit, type: :model do
   context "受診予定日が今日の場合" do
     let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: "10:00") }
 
-    it "有効である" do
+    it "今日の受診予定を登録できる" do
       expect(visit.valid?).to be true
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe Visit, type: :model do
   context "受診予定時間を現在時刻で登録した場合" do
     let(:visit) { build(:visit, user: user, department: department, visit_date: Date.today, appointed_at: Time.zone.now) }
 
-    it "無効である" do
+    it "受診予定時間が現在時刻と同じ場合は登録できない" do
       expect(visit.valid?).to be false
       expect(visit.errors[:appointed_at]).to include("は、現在以降の日時を指定してください。")
     end


### PR DESCRIPTION
## 概要
- NotificationモデルのFactoryを追加
- UserのFactoryでemailを一意に生成するよう修正
- Notificationモデルのバリデーションテストを追加
- Visitモデルの通知作成処理に関するテストを拡充
  - 即時通知/前日通知のタイトル・内容の検証
  - 通知がvisitとuserに紐付いて作成されることの確認
  - 通知作成時のis_sent初期値がfalseであることの確認

## 目的
通知関連の仕様を担保するためのテストを追加し、将来的なリファクタリングや機能修正時に不具合を検知できるようにする。

## 確認したところ
- `bundle exec rspec` が全てパスすること
- 即時通知・前日通知の内容が正しくテストされていること
- is_sentがfalseで作成されることが確認できること
