### PR TITLE
QuestionモデルのFactoryとバリデーションテストを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
   gem "dotenv-rails"
   gem "factory_bot_rails"
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-rails"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
@@ -69,9 +72,6 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
   gem "erb_lint"
-  gem "pry"
-  gem "pry-byebug"
-  gem "pry-rails"
   gem "letter_opener"
   gem "letter_opener_web"
   gem "rspec-rails"

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,21 +1,3 @@
-# == Schema Information
-#
-# Table name: questions
-#
-#  id                   :integer          not null, primary key
-#  content              :text             not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  department_id        :integer
-#  question_category_id :integer
-#
-# Indexes
-#
-#  index_questions_on_content_add_category_and_department  (content,question_category_id,department_id) UNIQUE
-#  index_questions_on_department_id                        (department_id)
-#  index_questions_on_question_category_id                 (question_category_id)
-#
-
 class Question < ApplicationRecord # #Questionモデルを定義
   belongs_to :department, optional: true # #department（診療科）に属することを示しつつ、optional: trueによって、診療科が未設定でも保存可能
   belongs_to :question_category, optional: true # 質問は question_category（カテゴリ）にも属す。任意であり、カテゴリがなくても保存可能とする。

--- a/spec/factories/question_categories.rb
+++ b/spec/factories/question_categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :question_category do
+    category_name { "カテゴリ" }
+  end
+end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :question do
+    association :department
+    association :question_category
+    content { "家で測った血圧が高めです" }
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Question, type: :model do
+  describe "バリデーション" do
+    context "質問内容が入力されている場合" do
+      let(:question) { build(:question, content: "家で測った血圧が高めです", department:, question_category: category) }
+      let(:category) { create(:question_category) }
+      let(:department) { create(:department) }
+
+      it "登録できる" do
+        expect(question.valid?).to be true
+      end
+    end
+
+    context "質問内容が空の場合" do
+      let(:department) { create(:department) }
+      let(:category) { create(:question_category) }
+      let(:question) { build(:question, content: "", department:, question_category: category) }
+
+      it "登録できない" do
+        expect(question.valid?).to be false
+        expect(question.errors[:content]).to include("を入力してください")
+      end
+    end
+
+    context "同じ診療科・カテゴリ内で質問内容が重複している場合" do
+      let(:department) { create(:department) }
+      let(:category) { create(:question_category) }
+      let(:existing_question) { create(:question, content: "この薬は続けて飲んでも大丈夫ですか", department:, question_category: category) }
+      let(:duplicate_question) { build(:question, content: "この薬は続けて飲んでも大丈夫ですか", department:, question_category: category) }
+
+      it "登録できない" do
+        existing_question
+        expect(duplicate_question.valid?).to be false
+        expect(duplicate_question.errors[:content]).to include("は、同じ診療科、カテゴリにすでにあります")
+      end
+    end
+
+    context "カテゴリが異なる場合" do
+      let(:department) { create(:department) }
+      let(:other_department) { create(:department) }
+      let(:category) { create(:question_category) }
+      let(:existing_question) { create(:question, content: "検査結果はいつわかりますか", department:, question_category: category) }
+      let(:new_question) { build(:question, content: "検査結果はいつわかりますか", department: other_department, question_category: category) }
+
+      it "登録できる" do
+        expect(new_question.valid?).to be true
+      end
+    end
+
+    context "診療科・カテゴリの指定" do
+      let(:question) { build(:question, content: "この薬は飲み続けても大丈夫ですか", department: nil, question_category: nil) }
+
+      it "どちらも指定されていない場合は登録できない" do
+        expect(question.valid?).to be false
+        expect(question.errors[:base]).to include("診療科に関する質問、またはカテゴリの質問のどちらかを選んでください")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
このプルリクエストでは、`Question` モデルのバリデーション仕様を確認するためのテスト環境を整備しました。FactoryBot によるデータ生成と、RSpec を用いたモデル単体テストを追加しています。

## 変更内容

### テストファクトリの追加
- **`spec/factories/question_categories.rb`**
  - `QuestionCategory` モデルの Factory を追加

- **`spec/factories/questions.rb`**
  - `Question` モデルの Factory を追加

### モデルテストの追加
- **`spec/models/question_spec.rb`**
  - 以下のバリデーションテストを追加
    - 質問内容の必須チェック
    - 同一カテゴリ・診療科の重複禁止
    - 異なるカテゴリ・診療科の重複許可
    - 診療科・カテゴリの両方未指定時のエラーメッセージ確認