### PR TITLE
QuestionSelectionモデルのバリデーションテストを追加

### DIFF
--- a/spec/factories/question_selections.rb
+++ b/spec/factories/question_selections.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :question_selection do
+    association :user
+    association :visit
+    association :question
+    selected_at { Time.current }
+  end
+end

--- a/spec/models/question_selection_spec.rb
+++ b/spec/models/question_selection_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe QuestionSelection, type: :model do
+  describe "バリデーション" do
+    let(:user) { create(:user) }
+    let(:visit) { create(:visit) }
+    let(:question) { create(:question) }
+
+    context "全ての情報が正しい場合" do
+      let(:selection) { build(:question_selection, user: user, visit: visit, question: question, selected_at: Time.current) }
+
+      it "質問を登録できる" do
+        expect(selection.valid?).to be true
+      end
+    end
+
+    context "選択日時が未設定の場合" do
+      let(:selection) { build(:question_selection, user: user, visit: visit, question: question, selected_at: nil) }
+
+      it "登録できない" do
+        expect(selection.valid?).to be false
+        expect(selection.errors[:selected_at]).to include("を入力してください")
+      end
+    end
+
+    context "同じ受診予定に同じ質問を重複して登録する場合" do
+      let!(:first_selection) { create(:question_selection, user: user, visit: visit, question: question) }
+      let(:duplicate) { build(:question_selection, user: user, visit: visit, question: question) }
+
+      it "重複登録できない" do
+        expect(duplicate.valid?).to be false
+        expect(duplicate.errors[:question_id]).to include("は、この予定にすでに登録されています")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
- QuestionSelectionモデルに対するRSpecテストを追加
#### 以下の3つのバリデーション仕様を確認
  - テスト内容
- 全ての情報が正しい場合
  - 質問選択が正常に登録されることを確認
- 選択日時が未設定の場合
  - バリデーションエラーとなり、エラーメッセージ「を入力してください」が返されることを確認
- 同じ受診予定に同じ質問を重複登録した場合
  - バリデーションにより登録できず、「は、この予定にすでに登録されています」というメッセージが表示されることを確認