### PR TITLE
VisitReminderJob のRSpecテストを追加

### DIFF
--- a/spec/jobs/visit_reminder_job_spec.rb
+++ b/spec/jobs/visit_reminder_job_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe VisitReminderJob, type: :job do
+  describe "#perform" do
+    it "翌日が期限の通知に対してリマインドメールを送信する" do
+      # モックの準備
+      target_date = Time.zone.tomorrow
+      notification = create(:notification, due_date: target_date, is_sent: false)
+
+      # NotificationMailerのモック
+      mailer_mock = double("NotificationMailer")
+
+      allow(NotificationMailer).to receive(:visit_reminder)
+        .with(notification)
+        .and_return(mailer_mock)
+      allow(mailer_mock).to receive(:deliver_now!)
+
+      # 実行する
+      described_class.new.perform
+
+      # 検証する
+      expect(NotificationMailer).to have_received(:visit_reminder).with(notification)
+      expect(mailer_mock).to have_received(:deliver_now!)
+    end
+
+    it "送信後に通知を送信すみに記録する" do
+      # 準備
+      target_date = Time.zone.tomorrow
+      notification = create(:notification, due_date: target_date, is_sent: false)
+
+      allow(NotificationMailer).to receive_message_chain(:visit_reminder, :deliver_now!)
+
+      # 実行
+      described_class.new.perform
+
+      # 検証
+      expect(notification.reload.is_sent).to eq(true)
+    end
+
+    it "受診予定日が翌日でない場合は送信しない" do
+      # 準備
+      notification = create(:notification, due_date: Time.zone.today, is_sent: false)
+
+      allow(NotificationMailer).to receive(:visit_reminder)
+
+      # 実行
+      described_class.new.perform
+
+      # 検証
+      expect(NotificationMailer).not_to have_received(:visit_reminder)
+      expect(notification.reload.is_sent).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
`VisitReminderJob`の動作を検証する RSpecテストを追加

## 変更内容
- `spec/jobs/visit_reminder_job_spec.rb`を新規作成
- モックを使用してメール送信 (`NotificationMailer.visit_reminder`) の呼び出しを検証
- `is_sent`フラグの更新が正しく行われることを確認
- 翌日以外の通知ではメール送信されないことを確認